### PR TITLE
Fix checksum

### DIFF
--- a/easybuild/easyconfigs/r/R-bundle-CRAN/R-bundle-CRAN-2024.06-foss-2023b.eb
+++ b/easybuild/easyconfigs/r/R-bundle-CRAN/R-bundle-CRAN-2024.06-foss-2023b.eb
@@ -1595,8 +1595,8 @@ exts_list = [
         'checksums': ['7c849086cb17d6c5aefc106217363e14afbcda2a9e0120687d40805b5e1c566a'],
     }),
     ('signal', '1.8-0', {
-        'checksums': ('0a604949bae91410a150a22cfa02d954f5b83166cc7a73e5409554d00e0417a7',   # older source
-                      '23ff303856ff09734e8ef280cec94556a15cdc702727ae5d02f8cfa4d8f473b7'),  # newer source
+        'checksums': [('0a604949bae91410a150a22cfa02d954f5b83166cc7a73e5409554d00e0417a7',    # older source
+                       '23ff303856ff09734e8ef280cec94556a15cdc702727ae5d02f8cfa4d8f473b7')],  # newer source
     }),
     ('tuneR', '1.4.7', {
         'checksums': ['364154a0440953327eeefd2f3c72c9f819944cbb52b6e7497958882ca0b6960a'],

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -1005,7 +1005,7 @@ class EasyConfigTest(TestCase):
                 if not easyconfig_dirs_regex.search(dirpath):
                     # only exception: TEMPLATE.eb
                     if not (dirpath.endswith('/easybuild/easyconfigs') and filenames == ['TEMPLATE.eb']):
-                        self.assertTrue(False, "List of easyconfig files in %s is empty: %s" % (dirpath, filenames))
+                        self.fail("List of easyconfig files in %s is empty: %s" % (dirpath, filenames))
 
     def test_easyconfig_name_clashes(self):
         """Make sure there is not a name clash when all names are lowercase"""
@@ -1026,7 +1026,7 @@ class EasyConfigTest(TestCase):
                 duplicates[name] = names[name]
 
         if duplicates:
-            self.assertTrue(False, "EasyConfigs with case-insensitive name clash: %s" % duplicates)
+            self.fail("EasyConfigs with case-insensitive name clash: %s" % duplicates)
 
     @skip_if_not_pr_to_non_main_branch()
     def test_pr_sha256_checksums(self):
@@ -1063,7 +1063,7 @@ class EasyConfigTest(TestCase):
                 retained_changed_ecs.append(ec)
 
         checksum_issues = check_sha256_checksums(retained_changed_ecs, whitelist=whitelist)
-        self.assertTrue(len(checksum_issues) == 0, "No checksum issues:\n%s" % '\n'.join(checksum_issues))
+        self.assertEqual(len(checksum_issues), 0, "Found checksum issues:\n" + '\n'.join(checksum_issues))
 
     @skip_if_not_pr_to_non_main_branch()
     def test_pr_python_packages(self):


### PR DESCRIPTION
The correct syntax is `[(cs1,cs2),cs_patch]`, i.e. we need the outer list and tuples in the elements

I also added a small fix for the error message from CI: 
> AssertionError: False is not true : No checksum issues:

That sounds weird...